### PR TITLE
Use `ignoreExitCode` on launching swiftlint

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -42,6 +42,6 @@ module.exports =
         parameters = parameters.concat ["--config", config] if config and fs.existsSync(config)
         additionalOptions = atom.config.get('linter-swiftlint.additionalOptions')
         parameters = parameters.concat additionalOptions if additionalOptions
-        options = {stdin: input, throwOnStdErr: false}
+        options = {ignoreExitCode: true, stdin: input, throwOnStdErr: false}
         helpers.exec(command, parameters, options).then (output) ->
           helpers.parse(output, regex, {filePath: filePath})


### PR DESCRIPTION
SwiftLint returns 2 as exit code when detecting style violations of severity "Error”.
https://github.com/realm/SwiftLint/pull/584

That produces error on running linter-swiftlint as following:
> Error: Process exited with non-zero code: 2

This commit avoid that error.