### PR TITLE
fix(package): update fs-plus to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "atom-linter": "^9.0.0",
     "atom-package-deps": "^4.0.1",
-    "fs-plus": "2.9.3"
+    "fs-plus": "3.0.0"
   },
   "package-deps": [
     "language-swift",


### PR DESCRIPTION
Closes #46

https://greenkeeper.io/

The major bump is just due to a drop of Node.js v4 support.