### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,15 @@ branches:
 
 git:
   depth: 10
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,25 @@
 ### Project specific config ###
-language: objective-c
-osx_image: xcode8.2
+language: node_js
+node_js: lts/*
+os: osx
 
 env:
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
 
-install:
+before_install:
   - brew update
   - brew outdated swiftlint || brew upgrade swiftlint
 
 ### Generic setup follows ###
-script:
+install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
   - ./build-package.sh
 
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
-branches:
-  only:
-    - master
-
-git:
-  depth: 10
-
-node_js: lts/*
+script:
+  - commitlint-travis
 
 after_success:
   # Add apm to the PATH

--- a/package.json
+++ b/package.json
@@ -41,5 +41,24 @@
       "value": 100,
       "level": "error"
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7"
+  },
+  "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,19 +3,16 @@
   "main": "./lib/init",
   "version": "1.2.2",
   "description": "Lint Swift files using swiftlint to offer style advice",
-  "keywords": [
-    "lint",
-    "swift",
-    "SwiftLint"
-  ],
-  "repository": "https://github.com/k2b6s9j/linter-swiftlint",
+  "keywords": ["lint", "swift", "SwiftLint"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-swiftlint.git"
+  },
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "os": [
-    "darwin"
-  ],
+  "os": ["darwin"],
   "providedServices": {
     "linter": {
       "versions": {
@@ -28,10 +25,7 @@
     "atom-package-deps": "^4.0.1",
     "fs-plus": "3.0.2"
   },
-  "package-deps": [
-    "language-swift",
-    "linter"
-  ],
+  "package-deps": ["language-swift", "linter"],
   "coffeelintConfig": {
     "indentation": {
       "level": "error",
@@ -46,9 +40,7 @@
     "extends": "@semantic-release/apm-config"
   },
   "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
+    "extends": ["@commitlint/config-conventional"]
   },
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
