### PR TITLE
chore(package): update atom-package-deps to version 4.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.6.2",
     "atom-ts-transpiler": "^1.5.2",
     "typescript": "^2.8.1"
   },


### PR DESCRIPTION
This includes many performance fixes that should probably be brought in as a minimum requirement.