### PR TITLE
Only run deploy on master and only build merge commits for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,21 @@ before_install:
 install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
+  - "./build-package.sh"
 
 script:
   - commitlint-travis
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+branches:
+  only:
+    - master
+    - "/^greenkeeper/.*$/"
+
+git:
+  depth: 10
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master
+
 jobs:
   include:
     - stage: release


### PR DESCRIPTION
* Use the conditional stages feature to only run the release stage when the build is on the `master` branch, and _isn't_ a pull request build.
* By default Travis Ci will run a build for the current `HEAD` of the branch the PR is on as well as the state of `master` after merging the PR branch. This changes it to only run on the `master` branch, with the exclusion of GreenKeeper's special builds.

  The net effect of this is PRs will only have one build to wait on.

